### PR TITLE
fix typo

### DIFF
--- a/library/analysis_tools/ma_plot/README.md
+++ b/library/analysis_tools/ma_plot/README.md
@@ -28,4 +28,4 @@ ma_plot_results = ma_plot.run(signature, pvalue_threshold="0.05", logfc_threshol
 ma_plot.plot(ma_plot_results)
 ```
 <img src="img/ma_plot-example.png"> 
-The MA Plot plug-in embeds an interactive scatter plot which displays the average expression and statistical significance of each gene calculated by performing differential gene expression analysis comparing samples in the Control group to samples in the Perturbation group. Every point in the plot represents a gene; additional information for each gene is available by hovering over it.
+The MA Plot plug-in embeds an interactive scatter plot which displays the average expression and log2-fold change of each gene calculated by performing differential gene expression analysis comparing samples in the Control group to samples in the Perturbation group. Every point in the plot represents a gene; additional information for each gene is available by hovering over it.


### PR DESCRIPTION
I believe the typo has been introduced due to copy and pasting the description from the Volcano Plot section. Also, I believe this fix should update the description shown on <https://maayanlab.cloud/biojupies/analyze/tools> page (in case it does not, it would be great to update the description there as well under MA plot section). 